### PR TITLE
Wrap table rebuild method in a try/catch statement

### DIFF
--- a/administrator/components/com_menus/models/item.php
+++ b/administrator/components/com_menus/models/item.php
@@ -1105,7 +1105,18 @@ class MenusModelItem extends JModelAdmin
 		$query = $db->getQuery(true);
 		$table = $this->getTable();
 
-		if (!$table->rebuild())
+		try
+		{
+			$rebuildResult = $table->rebuild();
+		}
+		catch (Exception $e)
+		{
+			$this->setError($e->getMessage());
+
+			return false;
+		}
+
+		if (!$rebuildResult)
 		{
 			$this->setError($table->getError());
 


### PR DESCRIPTION
Rebuild throws a database error when there are database errors (https://github.com/joomla/joomla-cms/blob/staging/libraries/joomla/table/nested.php#L1289). So wrap it in a try/catch. Note this will be the standard database message - which includes the prefix so I'm not sure at which step we show a more 'proper' message?
