### PR TITLE
Fix move/copy selection for fields batch modal

### DIFF
--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -19,6 +19,7 @@ JFactory::getDocument()->addScriptDeclaration(
 	'
 		jQuery(document).ready(function($){
 			if ($("#batch-category-id").length){var batchSelector = $("#batch-category-id");}
+			if ($("#batch-group-id").length){var batchSelector = $("#batch-group-id");}
 			if ($("#batch-menu-id").length){var batchSelector = $("#batch-menu-id");}
 			if ($("#batch-position-id").length){var batchSelector = $("#batch-position-id");}
 			if ($("#batch-copy-move").length) {


### PR DESCRIPTION
Fix for the jQuery snippet that shows and hides the move/copy radio buttons in the batch modal. It broke when the id on the group select changed to "batch-group-id".

Alternatively revert the ids to "batch-category-id" and save this extra line of JS.